### PR TITLE
Setup release structure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     node: true,
     browser: true,
   },
+  ignorePatterns: ["dist/**/*"],
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
   plugins: [],
   rules: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,16 @@ jobs:
       run: yarn install
     - name: Lint
       run: yarn run lint --no-fix --max-warnings 0 --format stylish
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Set up Node
+      uses: actions/setup-node@v2.2.0
+      with:
+        node-version: 'lts/*'
+        cache: 'yarn'
+    - name: Install dependencies
+      run: yarn install
+    - name: build
+      run: yarn build

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,37 @@
+name: Release Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - name: Set up Node
+      uses: actions/setup-node@v2.2.0
+      with:
+        node-version: 'lts/*'
+        cache: 'yarn'
+    - name: Install dependencies
+      run: yarn install
+    - name: build
+      run: yarn build
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+          cache: 'yarn'
+          registry-url: https://npm.pkg.github.com/
+      - run: yarn install
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -5,7 +5,8 @@ on:
     types: [created]
 
 jobs:
-  build:
+  npm-publish:
+    name: npm-publish
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
@@ -18,19 +19,11 @@ jobs:
       run: yarn install
     - name: build
       run: yarn build
-  publish-gpr:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 'lts/*'
-          cache: 'yarn'
-      - run: yarn install
-      - run: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Publish to NPM
+      uses: pascalgn/npm-publish-action@1.3.8
+      with:
+        publish_command: "yarn"
+        publish_args: "--non-interactive"
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'yarn'
-          registry-url: https://npm.pkg.github.com/
       - run: yarn install
       - run: yarn publish
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
-/dist
+/dist/*
+!/dist/.keep
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Accentor API Client
 
+## Install 
+Install using your package manger of choice:
+```
+yarn add @accentor/api-client-js
+npm install @accentor/api-client-js
+```
+
 ## How to use
 
 To intialize the API client:
 ```js
-import { createApiClient } from "api-client-js";
+import { createApiClient } from "@accentor/api-client-js";
 
 const baseURL = /* Your logic for baseURL, including /api/ */
 
@@ -44,7 +51,7 @@ If you want to filter the items fetched by through `indexGenerator`, you can pas
 
 An example of a scope used:
 ```js
-import { AlbumsScope } from "api-client-js";
+import { AlbumsScope } from "@accentor/api-client-js";
 
 const scope = new AlbumsScope.label(1);
 const generator = api.albums.indexGenerator(auth, scope)

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,0 +1,27 @@
+const esbuild = require("esbuild");
+
+const baseConfig = {
+  bundle: true,
+  entryPoints: ["src/index.js"],
+  external: ["fetch-retry"],
+  logLevel: "info",
+  minify: true,
+  sourcemap: true,
+  target: ["es2018"],
+};
+
+esbuild
+  .build({
+    ...baseConfig,
+    format: "esm",
+    outfile: "dist/index.mjs",
+  })
+  .catch(() => process.exit(1));
+
+esbuild
+  .build({
+    ...baseConfig,
+    format: "cjs",
+    outfile: "dist/index.js",
+  })
+  .catch(() => process.exit(1));

--- a/esbuild.js
+++ b/esbuild.js
@@ -14,7 +14,7 @@ esbuild
   .build({
     ...baseConfig,
     format: "esm",
-    outfile: "dist/index.mjs",
+    outfile: "dist/index.esm.js",
   })
   .catch(() => process.exit(1));
 
@@ -22,6 +22,6 @@ esbuild
   .build({
     ...baseConfig,
     format: "cjs",
-    outfile: "dist/index.js",
+    outfile: "dist/index.cjs.js",
   })
   .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-client-js",
+  "name": "@accentor/api-client-js",
   "version": "0.1.0",
   "description": "A javascript client for the Accentor API",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint . --ext .js --fix",
     "build": "node ./esbuild.js"
   },
-  "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
+  "author": "Team Accentor <team@accentor.tech>",
+  "contributors": [
+    "Robbe Van Petegem <robbe@vanpetegem.me>"
+  ],
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "api-client-js",
   "version": "0.1.0",
   "description": "A javascript client for the Accentor API",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "scripts": {
-    "lint": "eslint . --ext .js --fix"
+    "lint": "eslint . --ext .js --fix",
+    "build": "node ./esbuild.js"
   },
   "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
   "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   },
   "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
   "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "@accentor:registry": "https://npm.pkg.github.com"
+  },
+  "files": [
+    "dist/**/*"
+  ],
   "devDependencies": {
     "esbuild": "^0.12.15",
     "eslint": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
   },
   "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
   "license": "SEE LICENSE IN LICENSE",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "files": [
     "dist/**/*"
   ],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A javascript client for the Accentor API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "repository": "github:accentor/api-client-js",
   "scripts": {
     "lint": "eslint . --ext .js --fix",
     "build": "node ./esbuild.js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
+    "esbuild": "^0.12.15",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Robbe Van Petegem <robbe@vanpetegem.me>",
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {
-    "@accentor:registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com/"
   },
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@accentor/api-client-js",
   "version": "0.1.0",
   "description": "A javascript client for the Accentor API",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "repository": "github:accentor/api-client-js",
   "scripts": {
     "lint": "eslint . --ext .js --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,11 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
+esbuild@^0.12.15:
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.15.tgz#9d99cf39aeb2188265c5983e983e236829f08af0"
+  integrity sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

fix #4 

I went with esbuild, since [it should be the fastest option](https://esbuild.github.io/).

This PR sets up the following:
* Changes the package name to a scoped name. It will make more sense to import from `@accentor/api-client-js`
* Sets up the build process with esbuild for CJS and ESM
* Adds the build step to the github CI
* Adds a github actions workflow for releases. This is based on [the following article](https://docs.github.com/en/packages/quickstart), but I (obviously) was not able to test it.

I set the target to es2018, since this is the lowest version where esbuild is able to compile to [because we use async generators](https://esbuild.github.io/content-types/#javascript). If this proves to be a problem, we can add babel to transpile further down.