### PR TITLE
Import fetch-retry instead of using `require`

### DIFF
--- a/src/api_module.js
+++ b/src/api_module.js
@@ -1,11 +1,13 @@
 import { Scope } from "./scopes";
+import useFetchRetry from "fetch-retry";
 
-const fetchRetry = require("fetch-retry")(fetch, {
+const fetchRetry = useFetchRetry(fetch, {
   retries: 0,
   retryDelay: function (attempt) {
     return Math.pow(2, attempt) * 15000;
   },
 });
+
 export class ApiModule {
   constructor(path, routes) {
     this.path = path;


### PR DESCRIPTION
The use of `require("fetch-retry")` caused problems in the ESM build. I've switched to importing the dependency, which produces a working output.