### PR TITLE
Move `@babel/core` and `@babel/eslint-parser` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "dist/**/*"
   ],
   "devDependencies": {
+    "@babel/core": "^7.14.6",
+    "@babel/eslint-parser": "^7.14.7",
     "esbuild": "^0.12.15",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
@@ -25,8 +27,6 @@
     "prettier": "^2.3.2"
   },
   "dependencies": {
-    "@babel/core": "^7.14.6",
-    "@babel/eslint-parser": "^7.14.7",
     "fetch-retry": "^4.1.1"
   }
 }


### PR DESCRIPTION
We only need these for linting