### PR TITLE
Don't declare indexGenerator as async function

### DIFF
--- a/src/api_module.js
+++ b/src/api_module.js
@@ -11,13 +11,13 @@ export class ApiModule {
     this.path = path;
 
     if (routes.includes("index")) {
-      this.indexGenerator = async function (auth) {
+      this.indexGenerator = function (auth) {
         return this.#internalIndexGenerator(auth, new Scope());
       };
     }
 
     if (routes.includes("indexWithScope")) {
-      this.indexGenerator = async function (auth, scope = new Scope()) {
+      this.indexGenerator = function (auth, scope = new Scope()) {
         return this.#internalIndexGenerator(auth, scope);
       };
     }


### PR DESCRIPTION
the new `indexGenerator` functions aren't async, since they can return the `#internalIndexGenerator` immediatly