### PR TITLE
Fix rescan paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ const true = await api.tracks.destroy(auth, id);
 const true = await api.albums.destroyEmpty(auth, id);
 
 // Merge
-const result = await api.tracks.merge(auth, newId, oldID)
+const result = await api.tracks.merge(auth, newId, oldID);
+
+// Start rescan
+const result = await api.rescan.start(auth);
+
+// Get rescan status
+const result = await api.rescan.show(auth);
 ```
  
 ### Adding scopes to indexes

--- a/src/api_module.js
+++ b/src/api_module.js
@@ -35,7 +35,7 @@ export class ApiModule {
           },
           body: JSON.stringify(object),
         });
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
 
@@ -49,7 +49,7 @@ export class ApiModule {
             "x-device-id": auth.device_id,
           },
         });
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
 
@@ -64,7 +64,7 @@ export class ApiModule {
           },
           body: JSON.stringify(object),
         });
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
 
@@ -77,7 +77,7 @@ export class ApiModule {
             "x-device-id": auth.device_id,
           },
         });
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
 
@@ -91,7 +91,7 @@ export class ApiModule {
             "x-device-id": auth.device_id,
           },
         });
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
 
@@ -108,12 +108,12 @@ export class ApiModule {
             },
           }
         );
-        return await this.#resolveRequest(request);
+        return await this._resolveRequest(request);
       };
     }
   }
 
-  async #resolveRequest(request) {
+  async _resolveRequest(request) {
     let response, result;
     try {
       response = await fetchRetry(request);
@@ -167,4 +167,35 @@ export class ApiModule {
       page++;
     }
   }
+}
+
+export class RescanModule extends ApiModule {
+  constructor(path) {
+    super(path, []);
+  }
+
+  start = async function (auth, object) {
+    const request = new Request(`${this.path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+      body: JSON.stringify(object),
+    });
+    return await this._resolveRequest(request);
+  };
+
+  show = async function (auth, retryOptions = {}) {
+    const request = new Request(`${this.path}`, {
+      ...retryOptions,
+      method: "GET",
+      headers: {
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+    });
+    return await this._resolveRequest(request);
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { ApiModule } from "./api_module";
+import { ApiModule, RescanModule } from "./api_module";
 export * from "./scopes";
 
 export function createApiClient(baseURL) {
@@ -78,7 +78,7 @@ export function createApiClient(baseURL) {
       "destroy",
     ]),
     plays: new ApiModule(`${baseURL}/plays`, ["index", "create"]),
-    rescan: new ApiModule(`${baseURL}/rescan`, ["create", "read"]),
+    rescan: new RescanModule(`${baseURL}/rescan`),
     tracks: new ApiModule(`${baseURL}/tracks`, [
       "indexWithScope",
       "create",


### PR DESCRIPTION
For the rescan#read, we need to allow no ID to be passed. Before this `/api/rescan/undefined` was fetched.