### PR TITLE
Don't set "noEmit" to make sure npm-dts can emit

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "allowSyntheticDefaultImports": true,
     "lib": ["es2020", "es6", "dom"],
     "target": "es2018",
-    "noEmit": true,
     "declaration": true,    
     "baseUrl": "./src",
     "paths": {


### PR DESCRIPTION
I noticed v0.12.0 did not include a types declaration. Because we set "noEmit" in out tsconfig, npm-dts was not able to generate a config.
