### PR TITLE
Add application to auth token

### DIFF
--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -19,7 +19,7 @@ export interface AuthTokenParams {
   name: string;
   password: string;
   auth_token?: {
-    user_agent: string;
+    user_agent?: string;
     application?: string;
   };
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -8,6 +8,7 @@ export type AuthToken = {
   device_id: string;
   user_id: number;
   user_agent: string;
+  application?: string;
 };
 
 export type AuthTokenWithSecret = AuthToken & {
@@ -19,5 +20,6 @@ export interface AuthTokenParams {
   password: string;
   auth_token?: {
     user_agent: string;
+    application?: string;
   };
 }


### PR DESCRIPTION
This PR matches https://github.com/accentor/api/pull/622 - since we don't look inside the params, we only have to update the type.

I considered passing the `application` as an param of `createAPIClient` and injecting it in the request, but I thought it easier to simply pass the attribute in the application itself