### PR TITLE
Switch authorization to use new api token

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import useFetchRetry from "fetch-retry";
 import { Scope } from "./scopes";
-import { AuthInterface } from "./types/auth";
+import { ApiToken } from "./types/auth";
 import { RetryOptions } from "./types/fetch_retry";
 
 const fetchRetry = useFetchRetry(fetch, {
@@ -12,7 +12,7 @@ const fetchRetry = useFetchRetry(fetch, {
 
 export async function* indexGenerator<ReturnType, ST extends Scope>(
   path: string,
-  auth: AuthInterface,
+  apiToken: ApiToken,
   scope: ST,
 ): AsyncGenerator<ReturnType[], ReturnType[], void> {
   let page = 1;
@@ -23,8 +23,7 @@ export async function* indexGenerator<ReturnType, ST extends Scope>(
         retries: 5,
         method: "GET",
         headers: {
-          "x-secret": auth.secret,
-          "x-device-id": auth.device_id,
+          Authorization: `Bearer ${apiToken}`,
         },
       });
     } catch (error) {
@@ -49,15 +48,14 @@ export async function* indexGenerator<ReturnType, ST extends Scope>(
 
 export async function httpGet<ReturnType>(
   path: string,
-  auth: AuthInterface,
+  apiToken: ApiToken,
   retryOptions: RetryOptions,
 ): Promise<ReturnType> {
   const request = new Request(path, {
     ...retryOptions,
     method: "GET",
     headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
+      Authorization: `Bearer ${apiToken}`,
     },
   });
   return await resolve<ReturnType>(request);
@@ -65,15 +63,14 @@ export async function httpGet<ReturnType>(
 
 export async function httpPost<Params, ReturnType>(
   path: string,
-  auth: AuthInterface,
+  apiToken: ApiToken,
   data: Params,
 ): Promise<ReturnType> {
   const request = new Request(path, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
+      Authorization: `Bearer ${apiToken}`,
     },
     body: JSON.stringify(data),
   });
@@ -82,15 +79,14 @@ export async function httpPost<Params, ReturnType>(
 
 export async function httpPatch<Params, ReturnType>(
   path: string,
-  auth: AuthInterface,
+  apiToken: ApiToken,
   data: Params,
 ): Promise<ReturnType> {
   const request = new Request(path, {
     method: "PATCH",
     headers: {
       "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
+      Authorization: `Bearer ${apiToken}`,
     },
     body: JSON.stringify(data),
   });
@@ -99,13 +95,12 @@ export async function httpPatch<Params, ReturnType>(
 
 export async function httpDelete(
   path: string,
-  auth: AuthInterface,
+  apiToken: ApiToken,
 ): Promise<boolean> {
   const request = new Request(path, {
     method: "DELETE",
     headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
+      Authorization: `Bearer ${apiToken}`,
     },
   });
   return await resolve<boolean>(request);

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,18 +1,14 @@
-export interface AuthInterface {
-  secret: string;
-  device_id: string;
-}
+export type ApiToken = string;
 
 export type AuthToken = {
   id: number;
-  device_id: string;
   user_id: number;
   user_agent: string;
   application?: string;
 };
 
-export type AuthTokenWithSecret = AuthToken & {
-  secret: string;
+export type AuthTokenWithToken = AuthToken & {
+  token: ApiToken;
 };
 
 export interface AuthTokenParams {

--- a/test/integration/albums.test.ts
+++ b/test/integration/albums.test.ts
@@ -13,7 +13,7 @@ suite("AlbumModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/artists.test.ts
+++ b/test/integration/artists.test.ts
@@ -13,7 +13,7 @@ suite("ArtistModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/auth_tokens.test.ts
+++ b/test/integration/auth_tokens.test.ts
@@ -13,7 +13,7 @@ suite("AuthTokenModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/codec_conversions.test.ts
+++ b/test/integration/codec_conversions.test.ts
@@ -13,7 +13,7 @@ suite("CodecConversionModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/codecs.test.ts
+++ b/test/integration/codecs.test.ts
@@ -13,7 +13,7 @@ suite("CodecModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/cover_filenames.test.ts
+++ b/test/integration/cover_filenames.test.ts
@@ -13,7 +13,7 @@ suite("CoverFilenameModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/genres.test.ts
+++ b/test/integration/genres.test.ts
@@ -13,7 +13,7 @@ suite("GenreModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/image_types.test.ts
+++ b/test/integration/image_types.test.ts
@@ -13,7 +13,7 @@ suite("ImageTypeModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/labels.test.ts
+++ b/test/integration/labels.test.ts
@@ -13,7 +13,7 @@ suite("LabelModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/locations.test.ts
+++ b/test/integration/locations.test.ts
@@ -13,7 +13,7 @@ suite("LocationModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/playlists.test.ts
+++ b/test/integration/playlists.test.ts
@@ -13,7 +13,7 @@ suite("PlaylistModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/plays.test.ts
+++ b/test/integration/plays.test.ts
@@ -13,7 +13,7 @@ suite("PlayModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/rescans.test.ts
+++ b/test/integration/rescans.test.ts
@@ -13,7 +13,7 @@ suite("RescanModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/tracks.test.ts
+++ b/test/integration/tracks.test.ts
@@ -13,7 +13,7 @@ suite("TrackModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/integration/users.test.ts
+++ b/test/integration/users.test.ts
@@ -13,7 +13,7 @@ suite("UserModule", function () {
   teardown(() => fetchMock.clearHistory());
 
   test("should correctly call index path", async function () {
-    const index = module.index({ device_id: "abc", secret: "123" });
+    const index = module.index("123");
     const response = await index.next();
     assert(response.done);
     assert.equal(response.value.length, 0);

--- a/test/mock-api.ts
+++ b/test/mock-api.ts
@@ -8,7 +8,7 @@ fetchMock.mockGlobal();
 fetchMock.get(
   {
     url: "http://example.org/api/albums?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -18,7 +18,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/artists?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -28,7 +28,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/auth_tokens?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -38,7 +38,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/codec_conversions?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -48,7 +48,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/codecs?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -58,7 +58,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/cover_filenames?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -68,7 +68,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/genres?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -78,7 +78,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/image_types?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -88,7 +88,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/labels?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -98,7 +98,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/locations?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -108,7 +108,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/playlists?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -118,7 +118,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/plays?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -128,7 +128,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/rescans?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -138,7 +138,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/tracks?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",
@@ -148,7 +148,7 @@ fetchMock.get(
 fetchMock.get(
   {
     url: "http://example.org/api/users?page=1",
-    headers: { "x-secret": "123", "x-device-id": "abc" },
+    headers: { Authorization: "Bearer 123" },
   },
   {
     body: "[]",


### PR DESCRIPTION
Matches https://github.com/accentor/api/pull/721

This PR updates our API client to use a single `apiToken` for authorization. 
 
<!---
  If you did any manual testing (please do so), please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
