### PR TITLE
Fix module filename in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.23.2",
   "description": "A javascript client for the Accentor API",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "repository": "github:accentor/api-client-js",
   "scripts": {


### PR DESCRIPTION
This fixes an issue with the filename of our build output, which I missed in #567